### PR TITLE
fix(utility/date): fix case sensitive locale

### DIFF
--- a/src/date.ts
+++ b/src/date.ts
@@ -12,7 +12,7 @@
 export const getUSADateFormat = (dateString: string) => {
   const dateFormat = new Date(dateString);
 
-  const result = dateFormat.toLocaleString("en-us", {
+  const result = dateFormat.toLocaleString("en-US", {
     month: "short",
     day: "2-digit",
     year: "numeric",
@@ -35,7 +35,7 @@ export const getUSADateFormat = (dateString: string) => {
 export const getUSADateWithLongMonthFormat = (date: string) => {
   const dateFormat = new Date(date);
 
-  const result = dateFormat.toLocaleString("en-us", {
+  const result = dateFormat.toLocaleString("en-US", {
     month: "long",
     day: "2-digit",
     year: "numeric",


### PR DESCRIPTION
as states, In BCP 47 language tags, language and region codes are typically written in lowercase and uppercase, respectively. "en" represents the English language, and "US" represents the United States region. So, "en-US" specifies the English language as spoken in the United States.